### PR TITLE
Implement profile view and dark mode toggle

### DIFF
--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -1,0 +1,14 @@
+const {getPublicAccountById} = require('../services/auth.service');
+
+exports.getProfile = async (req, res) => {
+    try {
+        const user = await getPublicAccountById(req.params.id);
+        if (user) {
+            res.status(200).json(user);
+        } else {
+            res.status(404).json({error: 'User not found'});
+        }
+    } catch (err) {
+        res.status(500).json({error: err.message});
+    }
+};

--- a/server/routers/user.router.js
+++ b/server/routers/user.router.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const {authenticateToken} = require('../middlewares/auth.middleware');
+const {getProfile} = require('../controllers/user.controller');
+
+router.get('/:id', authenticateToken, getProfile);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -11,6 +11,7 @@ const authRouter = require('./routers/Auth.router');
 const friendRouter = require('./routers/friend.router');
 const conversationRouter = require('./routers/conversation.router');
 const imageRoutes = require('./routers/image.router');
+const userRouter = require('./routers/user.router');
 const jwt = require("jsonwebtoken");
 const path = require("path");
 
@@ -41,6 +42,7 @@ app.use('/auth/',authRouter );
 app.use('/friends/',friendRouter );
 app.use('/conversations/',conversationRouter);
 app.use('/image', imageRoutes);
+app.use('/users', userRouter);
 
 
 

--- a/server/services/auth.service.js
+++ b/server/services/auth.service.js
@@ -117,6 +117,21 @@ const setNewAvatar = async (id_user, avatar) => {
     }
 }
 
+const getPublicAccountById = async (id_user) => {
+    const client = await pool.connect();
+    try {
+        const sql = 'SELECT id, username, avatar, email FROM users WHERE id = $1';
+        const values = [id_user];
+        const result = await client.query(sql, values);
+        return result.rows[0];
+    } catch(err) {
+        console.log(err);
+        return null;
+    } finally {
+        client.release();
+    }
+}
+
 
 
 module.exports = {
@@ -125,5 +140,6 @@ module.exports = {
     createAccount,
     getAccountById,
     getAccountByUsername,
-    setNewAvatar
+    setNewAvatar,
+    getPublicAccountById
 }

--- a/server/services/conversation.service.js
+++ b/server/services/conversation.service.js
@@ -71,7 +71,7 @@ const  removeConversation = async (idConversation) => {
         let values = [idConversation];
 
         let result = await client.query(sql, values);
-        return result.row;
+        return result.rows[0];
     }catch (err){
         console.log(err)
         return []

--- a/server/services/message.service.js
+++ b/server/services/message.service.js
@@ -23,7 +23,7 @@ const  removeMessage = async (id_message) => {
         let values = [id_message];
 
         let result = await client.query(sql, values);
-        return result.row;
+        return result.rows[0];
     }catch (err){
         console.log(err)
         return []

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,7 @@ import {checkToken} from "@/services/login.service";
 export default {
   name: 'App',
   async created() {
+    this.$store.dispatch('loadTheme');
     let jwt = Cookies.get('jwt');
     if(jwt) {
        await checkToken().then(async (response) => {
@@ -39,7 +40,7 @@ export default {
 </script>
 
 <style>
-:root {
+:root[data-theme='dark'] {
   --primary-color: #2A2C30;
   --secondary-color: #303237;
   --tertiary-color: rgb(30, 31, 34);
@@ -47,6 +48,18 @@ export default {
   --actif-color: #FCFCFC;
   --selection-color: #3F4148;
   --inactif-color: #9299A2;
+  --red-color: #D12828;
+  --green-color: #007B00;
+}
+
+:root[data-theme='light'] {
+  --primary-color: #ffffff;
+  --secondary-color: #f4f4f4;
+  --tertiary-color: #e5e5e5;
+  --text-color: #1d1d1d;
+  --actif-color: #000000;
+  --selection-color: #cccccc;
+  --inactif-color: #555555;
   --red-color: #D12828;
   --green-color: #007B00;
 }

--- a/src/components/navbar.vue
+++ b/src/components/navbar.vue
@@ -98,7 +98,7 @@
             <i class="fas fa-sign-out-alt"></i>
             <span> Déconnexion</span>
           </div>
-          <div>
+          <div @click="toggleTheme">
             <i class="fas fa-moon"></i>
             <span>Apparance</span></div>
           <div>
@@ -158,6 +158,9 @@ export default {
   },
   methods: {
     getImage,
+    toggleTheme() {
+      this.$store.dispatch('toggleTheme');
+    },
     logout() {
       this.$store.dispatch('unAuthenticate').then(() => {
         this.$router.push('/login').catch(() => {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -69,6 +69,13 @@ const routes = [
       }
     ]
   },
+  {
+    path: '/profil/:id?',
+    name: 'profil',
+    meta: { requiresAuth: true },
+    component: () => import('../views/ProfilView.vue'),
+    props: true
+  },
 
   {
     path: "*",

--- a/src/services/profile.service.js
+++ b/src/services/profile.service.js
@@ -1,0 +1,9 @@
+import {getRequest} from '@/services/axios.service';
+
+export async function getProfile(id) {
+    const req = await getRequest(`/users/${id}`, 'getProfile');
+    if (req.status === 200) {
+        return {error: 0, data: req.data};
+    }
+    return {error: 1, data: req.data};
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -24,9 +24,11 @@ export default new Vuex.Store({
     userId: null,
     username: null,
     avatar: null,
+    email: null,
     token: null,
     conversations: [],
-    requestFriends: []
+    requestFriends: [],
+    theme: 'dark'
   },
   getters: {
     getSocket(state) {
@@ -44,6 +46,9 @@ export default new Vuex.Store({
     getAvatar(state) {
         return state.avatar;
     },
+    getEmail(state) {
+      return state.email;
+    },
     getToken(state) {
       return state.token;
     },
@@ -52,6 +57,9 @@ export default new Vuex.Store({
     },
     getRequestFriends(state) {
       return state.requestFriends;
+    },
+    getTheme(state) {
+      return state.theme;
     }
   },
   mutations: {
@@ -76,6 +84,9 @@ export default new Vuex.Store({
     setAvatar(state, avatar) {
     state.avatar = avatar;
     },
+    setEmail(state, email) {
+      state.email = email;
+    },
     addConversation(state, conversation) {
       state.conversations.push(conversation);
     },
@@ -85,8 +96,24 @@ export default new Vuex.Store({
     removeRequestFriends(state, id) {
          state.requestFriends.splice(state.requestFriends.findIndex(friend => friend.id === id), 1);
       }
+    ,setTheme(state, theme) {
+      state.theme = theme;
+    }
   },
   actions: {
+
+    loadTheme({commit}) {
+      const theme = localStorage.getItem('theme') || 'dark';
+      document.documentElement.setAttribute('data-theme', theme);
+      commit('setTheme', theme);
+    },
+
+    toggleTheme({commit, state}) {
+      const newTheme = state.theme === 'dark' ? 'light' : 'dark';
+      localStorage.setItem('theme', newTheme);
+      document.documentElement.setAttribute('data-theme', newTheme);
+      commit('setTheme', newTheme);
+    },
 
     initializeSocket({ commit ,rootState}) {
         const socket = connectSocket(Cookies.get('jwt'));
@@ -156,6 +183,7 @@ export default new Vuex.Store({
         commit('setUserId', data.userId);
         commit('setUsername', data.username);
         commit('setAvatar', data.avatar);
+        commit('setEmail', data.email);
         commit('setToken', data.token);
         axiosAgent.defaults.headers.common['Authorization'] = `Bearer ${data.token}`;
 
@@ -164,6 +192,7 @@ export default new Vuex.Store({
         commit('setIsAuthenticated', false);
         commit('setUserId', null);
         commit('setUsername', null);
+        commit('setEmail', null);
         commit('setToken', null);
         state.socket.disconnect();
         commit('setSocket', null);

--- a/src/variable.js
+++ b/src/variable.js
@@ -1,2 +1,1 @@
-
 export const API_URL = "http://localhost:3000";

--- a/src/views/ProfilView.vue
+++ b/src/views/ProfilView.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="profile-view">
+    <div class="profile-card">
+      <img :src="avatarUrl" class="avatar" alt="avatar" />
+      <h2>{{ profile.username }}</h2>
+      <p>{{ profile.email }}</p>
+      <div v-if="isOwnProfile" class="actions">
+        <input type="file" @change="upload" accept="image/*" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import {mapState} from 'vuex';
+import {getImage} from '@/services/image.service';
+import {getProfile} from '@/services/profile.service';
+
+export default {
+  name: 'ProfilView',
+  props: ['id'],
+  data() {
+    return {
+      profile: {}
+    }
+  },
+  computed: {
+    ...mapState(['userId', 'username', 'avatar', 'email']),
+    isOwnProfile() {
+      return !this.id || parseInt(this.id) === this.userId;
+    },
+    avatarUrl() {
+      const file = this.profile.avatar || this.avatar;
+      return getImage(file || 'default.png');
+    }
+  },
+  methods: {
+    async upload(e) {
+      const file = e.target.files[0];
+      if (!file) return;
+      const form = new FormData();
+      form.append('upload', file);
+      const res = await this.$store.dispatch('uploadAvatar', form);
+      if (res) {
+        this.profile.avatar = res;
+      }
+    }
+  },
+  async created() {
+    if (this.isOwnProfile) {
+      this.profile = {
+        username: this.username,
+        avatar: this.avatar,
+        email: this.email
+      };
+    } else {
+      const res = await getProfile(this.id);
+      if (res.error === 0) {
+        this.profile = res.data;
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.profile-view {
+  display: flex;
+  justify-content: center;
+  padding: 20px;
+}
+.profile-card {
+  background-color: var(--secondary-color);
+  padding: 20px;
+  border-radius: 10px;
+  text-align: center;
+  color: var(--text-color);
+}
+.avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+.actions input {
+  margin-top: 15px;
+}
+</style>


### PR DESCRIPTION
## Summary
- fix return values in message and conversation services
- allow public user lookup and add new user route
- tidy API base url file formatting
- implement theme handling with light/dark modes
- enable theme toggle in navbar
- show user profile page with avatar update

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68402b69eefc8330a943aee3a524205c